### PR TITLE
cleanup pacman cache

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -92,4 +92,4 @@ RUN userdel -r build && \
     sed -i '/root ALL=(ALL) NOPASSWD: ALL/d' /etc/sudoers && \
     rm -rf \
         /tmp/* \
-        /var/*
+	/var/cache/pacman/pkg/*


### PR DESCRIPTION
removing entire /var directory can make some issue on distrobox, so this pr will only deleting pacman cache