### PR TITLE
chore: move container build outside of the main build windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - main
   schedule:
-    - cron: '20 20 * * *'  # 8:20pm everyday
+    - cron: '20 18 * * *'  # 8:20pm everyday
   push:
     branches:
       - main


### PR DESCRIPTION
main and nvidia all run around this time so it probably makes sense to move this outside of their build window.