### PR TITLE
Fix mangohud

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -62,7 +62,6 @@ RUN pacman -S \
     pacman -S \
         steam \
         lutris \
-        lutris-wine-git \
         mangohud \
         lib32-mangohud \
         latencyflex \

--- a/Containerfile
+++ b/Containerfile
@@ -63,6 +63,8 @@ RUN pacman -S \
         steam \
         lutris \
         lutris-wine-git \
+        mangohud \
+        lib32-mangohud \
         latencyflex \
         vkbasalt \
         lib32-vkbasalt \
@@ -79,8 +81,6 @@ RUN git clone https://aur.archlinux.org/paru-bin.git --single-branch && \
     rm -drf paru-bin && \
     paru -S \
         aur/protontricks \
-        aur/mangohud \
-        aur/lib32-mangohud \
         --noconfirm
 USER root
 WORKDIR /


### PR DESCRIPTION
Moves mangohud's installation from the AUR to the official repos and removes lutris wine due to its dependency on mangohud-common