### PR TITLE
Remove Chaotic AUR

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -4,12 +4,6 @@ FROM docker.io/library/archlinux:latest
 RUN sed -i 's/#Color/Color/g' /etc/pacman.conf && \
     printf "[multilib]\nInclude = /etc/pacman.d/mirrorlist\n" | tee -a /etc/pacman.conf && \
     sed -i 's/#MAKEFLAGS="-j2"/MAKEFLAGS="-j$(nproc)"/g' /etc/makepkg.conf && \
-    pacman-key --init && \
-    pacman-key --populate archlinux && \
-    pacman-key --recv-key 3056513887B78AEB --keyserver keyserver.ubuntu.com && \
-    pacman-key --lsign-key 3056513887B78AEB && \
-    pacman -U 'https://cdn-mirror.chaotic.cx/chaotic-aur/chaotic-keyring.pkg.tar.zst' 'https://cdn-mirror.chaotic.cx/chaotic-aur/chaotic-mirrorlist.pkg.tar.zst' --noconfirm && \
-    printf "[chaotic-aur]\nInclude = /etc/pacman.d/chaotic-mirrorlist\n" | tee -a /etc/pacman.conf && \
     pacman -Syu --noconfirm && \
     pacman -S \
         wget \
@@ -62,7 +56,6 @@ RUN pacman -S \
         lutris \
         mangohud \
         lib32-mangohud \
-        vkbasalt \
         --noconfirm
         # Steam/Lutris/Wine installed separately so they use the dependencies above and don't try to install their own.
 
@@ -76,7 +69,11 @@ RUN git clone https://aur.archlinux.org/paru-bin.git --single-branch && \
     rm -drf paru-bin && \
     paru -S \
         aur/protontricks \
+        aur/vkbasalt \
+        aur/lib32-vkbasalt \
         aur/latencyflex-git \
+        aur/libstrangle-git \
+        aur/obs-vkcapture \
         --noconfirm
 USER root
 WORKDIR /


### PR DESCRIPTION
LatencyFleX is no longer built there and a log of the harder/longer building stuff has been removed since it was added, move to AUR.