### PR TITLE
fix: Add dependencies for pcem in lutris

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -65,6 +65,7 @@ RUN pacman -S \
         xdotool \
         xorg-xwininfo \
         wmctrl \
+        wxwidgets-gtk3 \
         --noconfirm && \
     pacman -S \
         steam \


### PR DESCRIPTION
Lutris has a runner named "PCEM". The standard `bazzite-arch` image is missing the dependency for this package to function correctly. 

If you look in the AUR, you'll see the package calls for `wxwidgets-gtk3`.
https://aur.archlinux.org/packages/pcem

This simply adds that to the standard image.