### PR TITLE
feat: add libbsd

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -33,6 +33,7 @@ RUN pacman -S \
         wxwidgets-gtk3 \
         rocm-opencl-runtime \
         rocm-hip-runtime \
+        libbsd \
         --noconfirm && \
     pacman -S \
         steam \


### PR DESCRIPTION
Without this library, some linux games like [Dead Cells](https://store.steampowered.com/app/588650/Dead_Cells/) dont work