### PR TITLE
chore: fix build | remove codeql from image for more disk space

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,8 @@ jobs:
     steps:
       - name: Maximize build space
         uses: ublue-os/remove-unwanted-software@v7
+        with:
+          remove-codeql: "true"
 
       # Checkout push-to-registry action GitHub repository
       - name: Checkout Push to Registry action


### PR DESCRIPTION
The removal of codeql from the builder image seems to get us enough free space for successful builds

https://github.com/herobrauni/bazzite-arch/actions/runs/12056538238