### PR TITLE
chore: fix build | Pacman Updated before installing

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -3,7 +3,7 @@ FROM ghcr.io/ublue-os/arch-distrobox AS bazzite-arch
 COPY system_files /
 
 # Install needed packages
-RUN pacman -S \
+RUN pacman -Syu \
         lib32-vulkan-radeon \
         libva-mesa-driver \
         intel-media-driver \


### PR DESCRIPTION
Could replicate the build failure from https://github.com/ublue-os/bazzite-arch/actions/runs/12070245811 in https://github.com/herobrauni/bazzite-arch/actions/runs/12071005029

Seems like updating pacman repos and packages first fixes it:
https://github.com/herobrauni/bazzite-arch/actions/runs/12071023333