### PR TITLE
chore: change base image from arch-distrobox to arch-toolbox

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/ublue-os/arch-distrobox@sha256:4e1a843bec9e2281694a089692002ce931dbc3c4ec6c6d12982b61840e68bd8b AS bazzite-arch
+FROM ghcr.io/ublue-os/arch-toolbox@sha256:bbc45bf0e4fc969b1bbcd366e893b1e03cc6228a1e5cca70e92eccd49b7f8cb4 AS bazzite-arch
 
 COPY system_files /
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Once the image has been created, you may optionally export the pre-installed app
     distrobox-enter -n bazzite-arch -- '  distrobox-export --app protontricks'
     distrobox-enter -n bazzite-arch -- '  mkdir -p ~/.steam && distrobox-export --bin /usr/bin/steamcmd --export-path ~/.steam && mv ~/.steam/steamcmd ~/.steam/steamcmd.sh'
 
-Bazzite-Arch is built from [arch-distrobox](https://github.com/ublue-os/arch-distrobox), which ships with [paru](https://github.com/Morganamilo/paru) pre-installed, along with a modified [xdg-utils](https://github.com/KyleGospo/xdg-utils-distrobox-arch) that allows the container to open your host operating system's web browsers and file explorer.
+Bazzite-Arch is built from [arch-toolbox](https://github.com/ublue-os/toolboxes/tree/main/toolboxes/arch-toolbox), which ships with [paru](https://github.com/Morganamilo/paru) pre-installed, along with a modified [xdg-utils](https://github.com/KyleGospo/xdg-utils-distrobox-arch) that allows the container to open your host operating system's web browsers and file explorer.
 
 ## Verification
 


### PR DESCRIPTION
see https://github.com/ublue-os/toolboxes/pull/141

Is this enough for renovate to pick it up?